### PR TITLE
Add GRPC_SERVER_ADDRESS configuration option

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,8 +44,10 @@ Text2Manim は、大規模言語モデル（LLM）と Manim を使用して、�
      - `SERVER_PORT`: API サーバーのポート（デフォルト: "50051"）
      - `LOG_LEVEL`: ログレベル（デフォルト: "INFO"）
      - `DB_TYPE`: データベースタイプ（"postgres" または "memory"）
+     - `GRPC_SERVER_ADDRESS`: gRPC サーバーアドレス（デフォルト: "localhost:50051"）
 
-     postgresを選択した場合の追加設定:
+     postgres を選択した場合の追加設定:
+
      - `DB_HOST`: PostgreSQL データベースホスト
      - `DB_PORT`: PostgreSQL データベースポート
      - `DB_USER`: PostgreSQL データベースユーザー名
@@ -53,6 +55,7 @@ Text2Manim は、大規模言語モデル（LLM）と Manim を使用して、�
      - `DB_NAME`: PostgreSQL データベース名
 
      注意:
+
      - 実運用環境では、セキュリティのために API キーとデータベース認証情報を変更することを強く推奨します。
      - `DB_TYPE` を "memory" に設定した場合、PostgreSQL 関連の設定は無視されます。
 
@@ -139,6 +142,7 @@ Text2Manim は、大規模言語モデル（LLM）と Manim を使用して、�
 - `DB_USER`: PostgreSQL データベースユーザー名
 - `DB_PASSWORD`: PostgreSQL データベースパスワード
 - `DB_NAME`: PostgreSQL データベース名
+- `GRPC_SERVER_ADDRESS`: gRPC サーバーアドレス
 
 ### worker/.env
 

--- a/api/.env.example
+++ b/api/.env.example
@@ -9,3 +9,4 @@ DB_PORT=[port]
 DB_USER=[username]
 DB_PASSWORD=[password]
 DB_NAME=postgres
+GRPC_SERVER_ADDRESS=localhost:50051

--- a/api/cmd/gateway/main.go
+++ b/api/cmd/gateway/main.go
@@ -6,17 +6,22 @@ import (
 	"net/http"
 	"os"
 
+	"github.com/KinjiKawaguchi/text2manim/api/internal/config"
 	pb "github.com/KinjiKawaguchi/text2manim/api/pkg/pb/text2manim/v1"
 	"github.com/grpc-ecosystem/grpc-gateway/v2/runtime"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials/insecure"
 )
 
-const grpcServerAddress = "api:50051"
-
 func main() {
 	logger := slog.New(slog.NewJSONHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelInfo}))
 	slog.SetDefault(logger)
+
+	cfg, err := config.LoadConfig(logger)
+	if err != nil {
+		logger.Error("Failed to load config", "error", err)
+		os.Exit(1)
+	}
 
 	ctx := context.Background()
 	ctx, cancel := context.WithCancel(ctx)
@@ -27,7 +32,7 @@ func main() {
 	)
 	opts := []grpc.DialOption{grpc.WithTransportCredentials(insecure.NewCredentials())}
 
-	err := pb.RegisterText2ManimServiceHandlerFromEndpoint(ctx, mux, grpcServerAddress, opts)
+	err = pb.RegisterText2ManimServiceHandlerFromEndpoint(ctx, mux, cfg.GrpcServerAddress, opts)
 	if err != nil {
 		slog.Error("Failed to register gRPC gateway", "error", err)
 		os.Exit(1)

--- a/api/internal/config/config.go
+++ b/api/internal/config/config.go
@@ -11,17 +11,18 @@ import (
 )
 
 type Config struct {
-	APIKeys     []string
-	IPWhitelist []string
-	WorkerAddr  string
-	ServerPort  string
-	LogLevel    string
-	DBType      string
-	DBHost      string
-	DBPort      string
-	DBUser      string
-	DBPassword  string
-	DBName      string
+	APIKeys           []string
+	IPWhitelist       []string
+	WorkerAddr        string
+	ServerPort        string
+	LogLevel          string
+	DBType            string
+	DBHost            string
+	DBPort            string
+	DBUser            string
+	DBPassword        string
+	DBName            string
+	GrpcServerAddress string
 }
 
 func LoadConfig(logger *slog.Logger) (*Config, error) {
@@ -32,17 +33,18 @@ func LoadConfig(logger *slog.Logger) (*Config, error) {
 	}
 
 	cfg := &Config{
-		APIKeys:     strings.Split(getEnv("API_KEYS", ""), ","),
-		IPWhitelist: strings.Split(getEnv("IP_WHITELIST", ""), ","),
-		WorkerAddr:  getEnv("WORKER_ADDR", "worker:50052"),
-		ServerPort:  getEnv("SERVER_PORT", "50051"),
-		LogLevel:    getEnv("LOG_LEVEL", "info"),
-		DBType:      getEnv("DB_TYPE", "memory"),
-		DBHost:      getEnv("DB_HOST", "localhost"),
-		DBPort:      getEnv("DB_PORT", "5432"),
-		DBUser:      getEnv("DB_USER", ""),
-		DBPassword:  getEnv("DB_PASSWORD", ""),
-		DBName:      getEnv("DB_NAME", ""),
+		APIKeys:           strings.Split(getEnv("API_KEYS", ""), ","),
+		IPWhitelist:       strings.Split(getEnv("IP_WHITELIST", ""), ","),
+		WorkerAddr:        getEnv("WORKER_ADDR", "worker:50052"),
+		ServerPort:        getEnv("SERVER_PORT", "50051"),
+		LogLevel:          getEnv("LOG_LEVEL", "info"),
+		DBType:            getEnv("DB_TYPE", "memory"),
+		DBHost:            getEnv("DB_HOST", "localhost"),
+		DBPort:            getEnv("DB_PORT", "5432"),
+		DBUser:            getEnv("DB_USER", ""),
+		DBPassword:        getEnv("DB_PASSWORD", ""),
+		DBName:            getEnv("DB_NAME", ""),
+		GrpcServerAddress: getEnv("GRPC_SERVER_ADDRESS", "localhost:50051"),
 	}
 
 	// APIキーの読み込み


### PR DESCRIPTION
This pull request adds a new configuration option, `GRPC_SERVER_ADDRESS`, which allows the user to specify the gRPC server address. This option is set to "localhost:50051" by default.