### PR TITLE
Add x-original-ip header to gRPC gateway requests

### DIFF
--- a/api/cmd/gateway/main.go
+++ b/api/cmd/gateway/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"log/slog"
+	"net"
 	"net/http"
 	"os"
 
@@ -11,6 +12,7 @@ import (
 	"github.com/grpc-ecosystem/grpc-gateway/v2/runtime"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/metadata"
 )
 
 func main() {
@@ -29,6 +31,7 @@ func main() {
 
 	mux := runtime.NewServeMux(
 		runtime.WithIncomingHeaderMatcher(CustomMatcher),
+		runtime.WithMetadata(addOriginalIPMetadata),
 	)
 	opts := []grpc.DialOption{grpc.WithTransportCredentials(insecure.NewCredentials())}
 
@@ -45,15 +48,22 @@ func main() {
 	}
 }
 
+func addOriginalIPMetadata(ctx context.Context, r *http.Request) metadata.MD {
+	ip, _, _ := net.SplitHostPort(r.RemoteAddr)
+	return metadata.Pairs("x-original-ip", ip)
+}
+
 func CustomMatcher(key string) (string, bool) {
 	switch key {
 	case "X-Api-Key":
 		return key, true
+	case "X-Original-Ip":
+		// このヘッダーは転送しない
+		return "", false
 	default:
 		return runtime.DefaultHeaderMatcher(key)
 	}
 }
-
 func loggingMiddleware(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		slog.Info("Received request",

--- a/api/internal/middleware/auth.go
+++ b/api/internal/middleware/auth.go
@@ -55,16 +55,23 @@ func (am *AuthMiddleware) authorize(ctx context.Context) error {
 }
 
 func (am *AuthMiddleware) checkIPWhitelist(ctx context.Context) error {
-	p, ok := peer.FromContext(ctx)
+	md, ok := metadata.FromIncomingContext(ctx)
 	if !ok {
-		am.logger.Error("Unable to get peer info")
-		return status.Error(codes.Unauthenticated, "unable to get peer info")
+		am.logger.Error("Unable to get metadata")
+		return status.Error(codes.Unauthenticated, "unable to get metadata")
 	}
 
-	ip, _, err := net.SplitHostPort(p.Addr.String())
-	if err != nil {
-		am.logger.Error("Unable to get IP address", "error", err)
-		return status.Error(codes.Unauthenticated, "unable to get IP address")
+	var ip string
+	originalIPs := md.Get("x-original-ip")
+	if len(originalIPs) > 0 {
+		ip = originalIPs[0]
+	} else {
+		p, ok := peer.FromContext(ctx)
+		if !ok {
+			am.logger.Error("Unable to get peer info")
+			return status.Error(codes.Unauthenticated, "unable to get peer info")
+		}
+		ip, _, _ = net.SplitHostPort(p.Addr.String())
 	}
 
 	for _, allowedIP := range am.config.IPWhitelist {
@@ -73,7 +80,6 @@ func (am *AuthMiddleware) checkIPWhitelist(ctx context.Context) error {
 			return nil
 		}
 	}
-
 	am.logger.Warn("IP not in whitelist", "ip", ip)
 	return status.Error(codes.PermissionDenied, "IP not in whitelist")
 }


### PR DESCRIPTION
This pull request adds the functionality to include the x-original-ip header in gRPC gateway requests. The header contains the original IP address of the client making the request. This information is extracted from the incoming HTTP request and added as metadata to the gRPC context. The header is then used by the gateway to pass the original IP address to downstream services. The x-original-ip header is not forwarded to the destination service, enhancing the security and logging capabilities of the system by preserving the original IP address of the client throughout the request flow. Fixes #<issue_number>